### PR TITLE
Use Pascal comment syntax in generated Pascal Script template

### DIFF
--- a/src/fu_script.pas
+++ b/src/fu_script.pas
@@ -257,8 +257,10 @@ begin
     end
     else begin
       if st=stPascal then begin
-        s.Add('# Pascal script for CCDciel');
-        s.Add('# see: https://www.ap-i.net/ccdciel/en/documentation/script_reference');
+        s.Add('{');
+        s.Add('Pascal script for CCDciel');
+        s.Add('see: https://www.ap-i.net/ccdciel/en/documentation/script_reference');
+        s.Add('}');
         s.Add('begin');
         s.Add('');
         s.Add('end.');

--- a/src/pu_edittargets.pas
+++ b/src/pu_edittargets.pas
@@ -1130,8 +1130,10 @@ begin
     end
     else begin
       if st=stPascal then begin
-        s.Add('# Pascal script for CCDciel');
-        s.Add('# see: https://www.ap-i.net/ccdciel/en/documentation/script_reference');
+        s.Add('{');
+        s.Add('Pascal script for CCDciel');
+        s.Add('see: https://www.ap-i.net/ccdciel/en/documentation/script_reference');
+        s.Add('}');
         s.Add('begin');
         s.Add('');
         s.Add('end.');


### PR DESCRIPTION
When creating a new pascal script the generated template is:
'# Pascal script for CCDciel'
'# see: https://www.ap-i.net/ccdciel/en/documentation/script_reference'

The symbol '#' is Python comment syntax, rather than Pascal script syntax.
This PR simply modifies it to Pascal Script syntax, that is:
{
Pascal script for CCDciel
see: https://www.ap-i.net/ccdciel/en/documentation/script_reference
}
begin

end.