### PR TITLE
Expose observer latitude/longitude/elevation values for scripting

### DIFF
--- a/src/pu_main.pas
+++ b/src/pu_main.pas
@@ -13249,6 +13249,9 @@ try
   else if method='CAPTURE_RUNNING' then result:=result+'"result": '+BoolToStr(f_Capture.Running,tr,fa)
   else if method='TELESCOPERA' then result:=result+'"result": '+FormatFloat(f6,mount.RA)
   else if method='TELESCOPEDE' then result:=result+'"result": '+FormatFloat(f6,mount.Dec)
+  else if method='OBS_LATITUDE' then result:=result+'"result": '+FormatFloat(f6,ObsLatitude)
+  else if method='OBS_LONGITUDE' then result:=result+'"result": '+FormatFloat(f6,-ObsLongitude)
+  else if method='OBS_ELEVATION' then result:=result+'"result": '+FormatFloat(f1,ObsElevation)
   else if method='CCDTEMP' then result:=result+'"result": '+FormatFloat(f2,camera.Temperature)
   else if method='FOCUSERPOSITION' then result:=result+'"result": '+IntToStr(focuser.Position)
   else if method='TIMENOW' then result:=result+'"result": "'+FormatDateTime(dateiso,now)+'"'


### PR DESCRIPTION
For calculating in Python CCDCiel scripts AZ/ALT coordinates
the latitude/longitude/elevation is required. This PR exposes
three additional script calls:

* OBS_LATITUDE
* OBS_LONGITUDE
* OBS_ELEVATION

which can be used e.g. as follows:

from astropy.coordinates import SkyCoord, EarthLocation, AltAz
from astropy.time import Time
from astropy import units as u
from ccdciel import ccdciel

time = (ccdciel('TIMENOW')['result'])
r = (ccdciel('TELESCOPERA')['result'])
d = (ccdciel('TELESCOPEDE')['result'])

la = (ccdciel('OBS_LATITUDE')['result'])
lo = (ccdciel('OBS_LONGITUDE')['result'])
el = (ccdciel('OBS_ELEVATION')['result'])

radec = SkyCoord(ra = r*u.degree, dec = d*u.degree, frame='icrs')
loc = EarthLocation(lat = la, lon = le, height = el*u.m)
altaz = AltAz(location = loc, obstime = time)
print(radec.transform_to(altaz).alt, radec.transform_to(altaz).az)