### PR TITLE
Unify JSONRPC call to connect or disconnect the devices

### DIFF
--- a/scripts/example/shutdown.script
+++ b/scripts/example/shutdown.script
@@ -24,7 +24,7 @@ ccdciel('Planetarium_shutdown')
 
 # Disconnect devices
 ccdciel('LOGMSG','Disconnect devices')
-ccdciel('DEVICESCONNECTION',False)
+ccdciel('DEVICES_CONNECTION',False)
 
 time.sleep(2)
 

--- a/scripts/example/startup.script
+++ b/scripts/example/startup.script
@@ -50,6 +50,6 @@ time.sleep(15)
 
 # Connect devices, this also connect PHD2 and Skychart if they are running
 ccdciel('LOGMSG','Connect devices')
-ccdciel('DEVICESCONNECTION',True)
+ccdciel('DEVICES_CONNECTION',True)
 
 ccdciel('LOGMSG','Startup complete')

--- a/src/pu_main.pas
+++ b/src/pu_main.pas
@@ -13288,7 +13288,7 @@ try
   else if method='AUTOFOCUS' then result:=result+'"result":{"status": "'+f_scriptengine.cmd_AutoFocus+'"}'
   else if method='AUTOMATICAUTOFOCUS' then result:=result+'"result":{"status": "'+f_scriptengine.cmd_AutomaticAutoFocus+'"}'
   // execute command with parameter
-  else if method='DEVICESCONNECTION' then begin
+  else if method='DEVICES_CONNECTION' then begin
     if uppercase(trim(value[attrib.IndexOf('params.0')]))='TRUE' then buf:='ON' else buf:='OFF';
     buf:=f_scriptengine.cmd_DevicesConnection(buf);
     result:=result+'"result":{"status": "'+buf+'"}';


### PR DESCRIPTION
The Pascalscript call for connecting and disconnecting devices is
"DEVICES_CONNECTION" whereas the JSONRPC is "DEVICESCONNECTION".
According to the CCDCiel documentation (wiki)
https://www.ap-i.net/ccdciel/en/documentation/jsonrpc_reference?s[]=jsonrpc
the JSONRPC call shall also be "DEVICES_CONNECTION".