### PR TITLE
Use UTF-8 arrows in TSpeedButton captions in option window.

### DIFF
--- a/src/pu_options.pas
+++ b/src/pu_options.pas
@@ -767,7 +767,7 @@ begin
   b.AllowAllUp:=true;
   b.Constraints.MinHeight:=DoScaleY(24);
   b.Layout:=blGlyphBottom;
-  b.Caption:='^';
+  b.Caption:='↑';
   b.tag:=1001;
   b.OnClick:=@IncPage;
   b.Parent:=PanelLeft;
@@ -787,7 +787,7 @@ begin
   b.AllowAllUp:=true;
   b.Constraints.MinHeight:=DoScaleY(24);
   b.Layout:=blGlyphBottom;
-  b.Caption:='v';
+  b.Caption:='↓';
   b.tag:=1002;
   b.OnClick:=@IncPage;
   b.Parent:=PanelLeft;


### PR DESCRIPTION
In option window the most upper and most lower TSpeedButton
caption is set to character '^' and 'v' resp. For cosmetic
appearance UTF-8 arrow '↑' and '↓' look more suitable.