### PR TITLE
When non-light subs are selected from the capture tab, also uncheck H…

### DIFF
--- a/src/fu_capture.lfm
+++ b/src/fu_capture.lfm
@@ -442,6 +442,7 @@ object f_capture: Tf_capture
         Top = 32
         Width = 251
         Caption = 'Autofocus after temperature change'
+	OnClick = CheckLight
         TabOrder = 2
       end
       object CheckBoxFocusHFD: TCheckBox
@@ -450,6 +451,7 @@ object f_capture: Tf_capture
         Top = 62
         Width = 229
         Caption = 'Autofocus after % change in HFD'
+	OnClick = CheckLight
         TabOrder = 3
       end
     end

--- a/src/fu_capture.pas
+++ b/src/fu_capture.pas
@@ -336,6 +336,8 @@ begin
   if cbFrameType.ItemIndex<>0 then begin
      CheckBoxDither.Checked:=false;
      CheckBoxFocus.Checked:=false;
+     CheckBoxFocusHFD.Checked:=false;
+     CheckBoxFocusTemp.Checked:=false;
   end;
   ExpTime.Enabled:=(cbFrameType.ItemIndex<>1);
   if ExpTime.Enabled and (ExpTime.Text='0') then ExpTime.ItemIndex:=0;

--- a/src/pu_main.pas
+++ b/src/pu_main.pas
@@ -11350,6 +11350,8 @@ if (AllDevicesConnected)and(not autofocusing)and (not learningvcurve) then begin
   if ftype<>LIGHT then begin
      f_capture.CheckBoxDither.Checked:=false;
      f_capture.CheckBoxFocus.Checked:=false;
+     f_capture.CheckBoxFocusHFD.Checked:=false;
+     f_capture.CheckBoxFocusTemp.Checked:=false;
   end;
   // set object for filename
   camera.ObjectName:=f_capture.Fname.Text;


### PR DESCRIPTION
When non-light subs are selected from the capture tab, currently only dithering and autofocus-every options are disabled; HFD and temp-based autofocus should also be disabled.