### PR TITLE
Fix image type set to « Light » for Darks and Flats

### DIFF
--- a/src/cu_camera.pas
+++ b/src/cu_camera.pas
@@ -786,7 +786,7 @@ begin
   if (hpix2>0) and (hbin2>0) then hpix2:=hpix2*hbin2;
   if hpix1<0 then if not f.Header.Valueof('XPIXSZ',hpix1) then hpix1:=-1;
   if hpix2<0 then if not f.Header.Valueof('YPIXSZ',hpix2) then hpix2:=-1;
-  if not f.Header.Valueof('FRAME',hframe)   then hframe:='Light   ';
+  if not f.Header.Valueof('IMAGETYP',hframe)   then hframe:='Light   ';
   if not f.Header.Valueof('FILTER',hfilter) then hfilter:='';
   if not f.Header.Valueof('DATAMIN',hdmin)  then hdmin:=f.HeaderInfo.dmin;
   if not f.Header.Valueof('DATAMAX',hdmax)  then hdmax:=f.HeaderInfo.dmax;


### PR DESCRIPTION
When I take flat fields and dark frames, they are tagged as Light in the FITS header. Looking at the blob produced by Indigo, the IMAGETYP keyword has the correct value, "Flat", or "Dark". It is reset to "Light" by CCDCiel.
Looking at the code, I found this line, using a "FRAME" keyword, which I could not find in any documentation of the FITS keywords. Setting an artificial FRAME keyword on Indigo side did the trick, and confirmed that this specific line is the cause of the reset to "Light".
Unfortunately, I cannot compile CCDCiel for the moment (macOS 15 rejects the installation of the FreePascal source package), but the fix seems so obvious that I put forward this pull request.
If I've overlooked that the "FRAME" keyword is in fact supported by some software, the test would need complement, but the "IMAGETYP" keyword should still get priority, as it is clearly specified in the FITS documentation.