### PR TITLE
Fix various typos

### DIFF
--- a/src/cu_autoguider_internal.pas
+++ b/src/cu_autoguider_internal.pas
@@ -152,7 +152,7 @@ begin
 end;
 
 
-procedure get_best_mean(list: array of double; leng : integer; out mean : double);{Remove outliers from polulation using MAD. }
+procedure get_best_mean(list: array of double; leng : integer; out mean : double);{Remove outliers from population using MAD. }
 var  {idea from https://eurekastatistics.com/using-the-median-absolute-deviation-to-find-outliers/}
   i,count         : integer;
   median, mad     : double;
@@ -409,7 +409,7 @@ begin
       if raonly then
         ddec:=0
       else
-        ddec:=(2*random-1)*pixel;//DEC dither ammount in pixels
+        ddec:=(2*random-1)*pixel;//DEC dither amount in pixels
     end;
 
     // move fast for the first pulse
@@ -508,7 +508,7 @@ begin
   end;
 end;
 
-function  T_autoguider_internal.measure_drift(var initialize:boolean; out drX,drY :double) : integer;// ReferenceX,Y indicates the total drift, drX,drY to drift since previouse call. Arrays old_xy_array,xy_array are for storage star positions
+function  T_autoguider_internal.measure_drift(var initialize:boolean; out drX,drY :double) : integer;// ReferenceX,Y indicates the total drift, drX,drY to drift since previous call. Arrays old_xy_array,xy_array are for storage star positions
 var
   i,fitsx,fitsy,stepsize,xsize,ysize,star_counter,star_counter2,counter,len,maxSNRstar,ix,iy: integer;
   hfd1,star_fwhm,vmax,bg,bgdev,xc,yc,snr,flux,fluxratio,min_SNR,min_HFD,maxSNR,margin,y,mhfd,peak : double;
@@ -820,14 +820,14 @@ begin
     peak:=0;
     for i:=0 to length(xy_array_old)-1 do
     begin
-      if xy_array_old[i].flux<>0 then // Previouse dection, keep tracking this star while it drifts away
+      if xy_array_old[i].flux<>0 then // Previous detection, keep tracking this star while it drifts away
       begin //try first within a small area
         guidefits.GetHFD3(round(xy_array_old[i].x2),round(xy_array_old[i].y2),round(mean_hfd*3.5){smaller search area},true{autocenter},xc,yc,bg,bgdev,hfd1,star_fwhm,vmax,snr,flux,false);
        if snr<1 then // no detection, look wider
         guidefits.GetHFD3(round(xy_array_old[i].x2),round(xy_array_old[i].y2),searchA{area},true{autocenter},xc,yc,bg,bgdev,hfd1,star_fwhm,vmax,snr,flux,false) // use a larger search area
       end
       else // try in the initial area
-        guidefits.GetHFD3(round(xy_array_old[i].x1),round(xy_array_old[i].y1),searchA,true{autocenter},xc,yc,bg,bgdev,hfd1,star_fwhm,vmax,snr,flux,false);// find a star in the orginal segment
+        guidefits.GetHFD3(round(xy_array_old[i].x1),round(xy_array_old[i].y1),searchA,true{autocenter},xc,yc,bg,bgdev,hfd1,star_fwhm,vmax,snr,flux,false);// find a star in the original segment
 
       if ((snr>max(min_SNR-10,6)) and (hfd1>Min_HFD)) then // star detection
       begin // star in this area
@@ -1388,7 +1388,7 @@ var i,maxpulse    : integer;
                 mflipcorr:=0;
 
               if finternalguider.pulsegainNorth<0 then flipDec:=-1 else flipDec:=+1;//flipped image correction. E.g. an image where north is up and east on the right size.
-              rotate2(((+finternalguider.PA+mflipcorr)*pi/180),dRaPixelsSolar,flipDec*dDecPixelsSolar,delta_ditherX,delta_ditherY);// rotate RA, DEC drift scope to X,Y drift guider image. Positive ditherY is go North. Postive ditherX is go West!
+              rotate2(((+finternalguider.PA+mflipcorr)*pi/180),dRaPixelsSolar,flipDec*dDecPixelsSolar,delta_ditherX,delta_ditherY);// rotate RA, DEC drift scope to X,Y drift guider image. Positive ditherY is go North. Positive ditherX is go West!
               ditherX:=ditherX+delta_ditherX; //integrate offset solar object in X
               ditherY:=ditherY+delta_ditherY; //integrate offset solar object in Y
               Finternalguider.OffsetX:=ditherX;  // show in spectro offset
@@ -1598,7 +1598,7 @@ begin
 
     end;
 
-    // wait for puls guide move completed
+    // wait for pulse guide move completed
     if maxpulse>finternalguider.shortestPulse then
     begin
       WaitPulseGuiding(maxpulse);//If this timer has run a new exposure is started
@@ -2616,7 +2616,7 @@ try
     if n<>0 then begin msg('Guide star out of frame x='+FormatFloat(f1,c.x)+' y='+FormatFloat(f1,c.y),1); exit; end;
     xg:=c.x;
     yg:=c.y;
-    // offset fron object to guide
+    // offset from object to guide
     xo:=xg-xt;
     yo:=yg-yt;
     // correction for pier side
@@ -2689,7 +2689,7 @@ try
       end
       else if Finternalguider.GuideLock then begin
          // try to find the brightest star instead
-         msg('Astrometry fail, try to use the brigthest star instead of the specified coordinates',1);
+         msg('Astrometry fail, try to use the brightest star instead of the specified coordinates',1);
          finternalguider.GuideLockNextX:=-10;
          finternalguider.GuideLockNextY:=-10;
          result:=false;

--- a/src/cu_fits.pas
+++ b/src/cu_fits.pas
@@ -1164,7 +1164,7 @@ for i:=startline to endline do begin
    p := bgra.Scanline[i];
    for j := 0 to xs-1 do begin
        if fits.preview_axis=3 then begin
-         // 3 chanel color image
+         // 3 channel color image
          xx:=fits.Fimage[0,i,j];
          x:=round(max(0,min(MaxWord,(xx-vmin) * c )) );
          p^.red:=fits.GammaCorr(x);
@@ -1233,7 +1233,7 @@ for i:=startline to endline do begin
    p := bgra.Scanline[i];
    for j := 0 to xs-1 do begin
        if fits.preview_axis=3 then begin
-         // 3 chanel color image
+         // 3 channel color image
          xx:=(fits.Fimage[0,i,j]-minv)*c;
          x:=round(max(0,min(MaxWord,xx)) );
          p^.red:=x;
@@ -3100,7 +3100,7 @@ begin
   try
     calculate_bg_sd(Fimage,x,y,rs,4,bg,sd); {calculate background and standard deviation for position x,y around box rs x rs. }
 
-    // Get center of gravity whithin star detection box
+    // Get center of gravity within star detection box
     SumVal:=0;
     SumValX:=0;
     SumValY:=0;
@@ -3166,7 +3166,7 @@ end;
 procedure TFits.FindStarPos2(x,y,s: integer; out xc,yc,vmax,bg,sd: double);
 // center of gravity in area s*s centered on x,y
 // same as FindStarPos but with floating point xc,yc and without the radius computation
-// this is used for autoguiding on spectro slit, with possible splited star image
+// this is used for autoguiding on spectro slit, with possible split star image
 const
     max_ri=100;
 var i,j,rs :integer;
@@ -3184,7 +3184,7 @@ begin
   try
     calculate_bg_sd(Fimage,x,y,rs,4,bg,sd); {calculate background and standard deviation for position x,y around box rs x rs. }
 
-    // Get center of gravity whithin star detection box
+    // Get center of gravity within star detection box
     SumVal:=0;
     SumValX:=0;
     SumValY:=0;
@@ -3265,7 +3265,7 @@ begin
     calculate_bg_sd(Fimage,x,y,rs,4,bg,sd); {calculate background and standard deviation for position x,y around box rs x rs. }
 
     repeat {## reduce box size till symmetry to remove stars}
-      // Get center of gravity whithin star detection box and count signal pixels
+      // Get center of gravity within star detection box and count signal pixels
       SumVal:=0;
       SumValX:=0;
       SumValY:=0;
@@ -3360,7 +3360,7 @@ begin
      ri:=3; {Minimum 6+1 x 6+1 pixel box}
     end;
 
-    // Get HFD using the aproximation routine assuming that HFD line divides the star in equal portions of gravity:
+    // Get HFD using the approximation routine assuming that HFD line divides the star in equal portions of gravity:
     SumVal:=0;
     SumValR:=0;
     pixel_counter:=0;
@@ -3491,7 +3491,7 @@ begin
     calculate_bg_sd(Fimage,x,y,rs,4,bg,sd); {calculate background and standard deviation for position x,y around box rs x rs. }
 
     repeat {## reduce box size till symmetry to remove stars}
-      // Get center of gravity whithin star detection box and count signal pixels
+      // Get center of gravity within star detection box and count signal pixels
       SumVal:=0;
       SumValX:=0;
       SumValY:=0;
@@ -3592,7 +3592,7 @@ begin
      ri:=3; {Minimum 6+1 x 6+1 pixel box}
     end;
 
-    // Get HFD using the aproximation routine assuming that HFD line divides the star in equal portions of gravity:
+    // Get HFD using the approximation routine assuming that HFD line divides the star in equal portions of gravity:
     SumVal:=0;
     SumValR:=0;
     pixel_counter:=0;

--- a/src/cu_indimount.pas
+++ b/src/cu_indimount.pas
@@ -1204,7 +1204,7 @@ end;
 
 function T_indimount.GetMountRefraction: TMountRefraction;
 begin
-  // no propetry in INDI ?
+  // no property in INDI ?
   result:=refractUnknown;
 end;
 

--- a/src/cu_targets.pas
+++ b/src/cu_targets.pas
@@ -726,7 +726,7 @@ begin
   // save the updated file
   SaveTargets(FSequenceFile.Filename);
 
-  // Apply startup change immediatelly only if the sequence is waiting to start
+  // Apply startup change immediately only if the sequence is waiting to start
   if StartChange and WaitStarting then begin
     msg(rsRestartTheSe, 3);
     if assigned(FonRestart) then FonRestart(self);
@@ -1601,7 +1601,7 @@ begin
      etime:=stime+stw/secperday;
    end
    else
-     etime:=MaxDouble;             // no end time, can run infinitly
+     etime:=MaxDouble;             // no end time, can run infinitely
    twok:=TwilightAstro(now,hm,he);  // compute twilight
    if twok then begin
      if he<12 then he:=he+24;
@@ -1720,7 +1720,7 @@ begin
             txt:=txt+','+blank+rsStartAt+FormatDateTime(datehms, ctime);
           end
           else begin
-            // target is already completly done
+            // target is already completely done
             dotarget:=false;
             txt:=txt+','+blank+rsDone;
           end;
@@ -1789,7 +1789,7 @@ begin
         // total execution time for target
         targettime:=targettime*(t.repeatcount-t.repeatdone);
         if dotarget and (targettime>forceendtime) then begin
-           // interupted by object set
+           // interrupted by object set
            targettime:=forceendtime;
            forceset:=true;
         end
@@ -1803,13 +1803,13 @@ begin
           txt:=txt+','+blank+'Sequence elapsed time'+':'+blank+TimToStr(totaltime/3600,'h',false);
           FDoneStatus:=FDoneStatus+crlf+txt;
           if FSeqStop and (ctime>etime) then begin
-            // interupted by sequence end time
+            // interrupted by sequence end time
             txt:=t.objectname+blank+'Interrupted by end of sequence at:'+blank+FormatDateTime(datehms,etime);
             seqbreak:=true;
           end
           else begin
             if forceset then
-              // interupted by object set
+              // interrupted by object set
               txt:=t.objectname+blank+'Interrupted at:'+blank+FormatDateTime(datehms,ctime)
             else
               // completed time
@@ -2412,7 +2412,7 @@ begin
     chkendtime:=rmod(t.endtime-enddelay+1,1);
     // test if in time interval
     intime:=InTimeInterval(frac(now),t.starttime,chkendtime,st/24);
-    // test if skiped
+    // test if skipped
     if t.skip then begin
       skipmsg:='';
       if (intime<0) and (t.starttime>=0) then begin

--- a/src/cu_tcpserver.pas
+++ b/src/cu_tcpserver.pas
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 }
 
-{ TCP/IP Connexion, based on Synapse Echo demo }
+{ TCP/IP Connection, based on Synapse Echo demo }
 
 {$MODE objfpc}{$H+}
 

--- a/src/fu_capture.pas
+++ b/src/fu_capture.pas
@@ -348,7 +348,7 @@ begin
   ExpTime.Enabled:=(cbFrameType.ItemIndex<>1);
   if ExpTime.Enabled and (ExpTime.Text='0') then ExpTime.ItemIndex:=0;
   if Sender<>nil then begin
-    // run custom frame type script immediatelly when changed interactively
+    // run custom frame type script immediately when changed interactively
     if assigned(FonFrameTypeChange) then FonFrameTypeChange(self);
   end;
 end;

--- a/src/pu_collimation.lfm
+++ b/src/pu_collimation.lfm
@@ -143,7 +143,7 @@ object f_collimation: Tf_collimation
         AutoSize = False
         BorderSpacing.Top = 4
         BorderSpacing.Around = 4
-        Caption = 'Inspect the distribution of the HFD across the image to help with coma corrector spacing and tilt adjustement.'
+        Caption = 'Inspect the distribution of the HFD across the image to help with coma corrector spacing and tilt adjustment.'
         ParentColor = False
         WordWrap = True
       end

--- a/src/pu_devicesetup.lfm
+++ b/src/pu_devicesetup.lfm
@@ -654,7 +654,7 @@ object f_setup: Tf_setup
                 object CameraIndiTransfertDir: TEdit
                   Left = 96
                   Height = 28
-                  Hint = 'The temporary RAM disk used to transfert the images '#10'from the Indi server'
+                  Hint = 'The temporary RAM disk used to transfer the images '#10'from the Indi server'
                   Top = 2
                   Width = 254
                   Constraints.MaxHeight = 28

--- a/src/pu_image_sharpness.pas
+++ b/src/pu_image_sharpness.pas
@@ -55,7 +55,7 @@ begin
   end;//for loop
 
   if Sharpness>0 then
-    result := 100*width*height/sqrt(Sharpness) //turn the curve upside down and scale simular as HFD values. A lower value indicates a sharper image
+    result := 100*width*height/sqrt(Sharpness) //turn the curve upside down and scale similar to HFD values. A lower value indicates a sharper image
   else
     result:=9999;//dummy value for case sharpness is zero
 end;

--- a/src/pu_main.pas
+++ b/src/pu_main.pas
@@ -10950,7 +10950,7 @@ end;
 
 procedure Tf_main.CaptureFrameTypeChange(Sender: TObject);
 begin
-  // run custom frame type script immediatelly when changed interactively
+  // run custom frame type script immediately when changed interactively
   camera.InitFrameType(f_capture.FrameType)
 end;
 
@@ -11860,7 +11860,7 @@ begin
   NewMessage(Format(rsFlatLevel, [inttostr(round(fits.imageFlatLevel))]),2);
   // adjust exposure time only once per series
   if AdjustDomeFlat then begin
-    // new exposure adjustement
+    // new exposure adjustment
     expadjust:=DomeFlatLevel/fits.imageFlatLevel;
     exp:=StrToFloatDef(f_capture.ExpTime.Text,FlatMinExp);
     newexp:=exp*expadjust;
@@ -11870,12 +11870,12 @@ begin
          (sgn(DomeFlatExpAdjust-1)=sgn(expadjust-1)) // same direction
         )
        ) then begin
-      // continue adjustement
+      // continue adjustment
       DomeFlatExpAdjust:=expadjust;
       result:=false;
     end
     else begin
-      // not saturated, small change, direction reversal: make last adjustement and stop to prevent oscillation
+      // not saturated, small change, direction reversal: make last adjustment and stop to prevent oscillation
       AdjustDomeFlat:=false;
       doFlatAutoExposure:=false;
       result:=true;
@@ -14454,7 +14454,7 @@ begin
     f_starprofile.ChkAutofocusDown(false);
     exit;
   end;
-  // protect again wrong settting
+  // protect against wrong setting
   if AutofocusExposureFact<=0 then AutofocusExposureFact:=1;
   if AutofocusExposure<=0 then AutofocusExposure:=1;
   // start a new exposure as the current frame is probably not a preview
@@ -16142,7 +16142,7 @@ begin
 end;
 
 
-function fnmodulo2(x,range: double):double;   {specifiy range=2*pi fore -pi..pi or range=360 for -180.. 180}
+function fnmodulo2(x,range: double):double;   {specify range=2*pi fore -pi..pi or range=360 for -180.. 180}
 begin
   result:=x;
   while result<-range/2 do result:=result+range;

--- a/src/pu_options.lfm
+++ b/src/pu_options.lfm
@@ -3407,7 +3407,7 @@ object f_option: Tf_option
             AnchorSideTop.Side = asrCenter
             Left = 214
             Height = 22
-            Hint = 'The prefered focuser direction for autofocus.'
+            Hint = 'The preferred focuser direction for autofocus.'
             Top = 91
             Width = 41
             Caption = 'In'
@@ -3420,7 +3420,7 @@ object f_option: Tf_option
           object AutofocusMoveDirOut: TRadioButton
             Left = 369
             Height = 22
-            Hint = 'The prefered focuser direction for autofocus.'
+            Hint = 'The preferred focuser direction for autofocus.'
             Top = 91
             Width = 51
             Caption = 'Out'

--- a/src/pu_polaralign.pas
+++ b/src/pu_polaralign.pas
@@ -146,7 +146,7 @@ type
   (* A double precision point *)
   TPointDouble = packed record x, y: double;
   end;
-  {* Defition of a line in the euclidian plane }
+  {* Definition of a line in the euclidean plane }
   TLineDouble = record
     {** Some point in the line }
     origin: TPointDouble;

--- a/src/pu_polaralign2.pas
+++ b/src/pu_polaralign2.pas
@@ -500,7 +500,7 @@ end;
    where da is the polar error in azimuth
    where h is the hour angle of the reference point equal ra - local_sidereal_time
 
- Using the above formula calculate the difference in RA and DEC by subtracting the first image postion from the second reference image. The common term sin(lat) will be nulified. Formula (4)
+ Using the above formula calculate the difference in RA and DEC by subtracting the first image position from the second reference image. The common term sin(lat) will be nulified. Formula (4)
  delta_ra:= de * (TAN(dec2)*SIN(h_2)-TAN(dec1)*SIN(h_1))  + da * COS(lat)*(TAN(dec1)*COS(h_1)-TAN(dec2)*COS(h_2));
  delta_dec:=de * (COS(h_2)-COS(h_1))  + da * COS(lat)*(SIN(h_2)-SIN(h_1));
 
@@ -631,7 +631,7 @@ begin
        // store center
        Fcra:=cra;
        Fcde:=cde;
-       // adjustement at current position
+       // adjustment at current position
        CurrentAdjustement(cra,cde);
        tracemsg('Stars in new image have to move: '+FormatFloat(f2,rad2deg*(corr_ra/max(0.00000000000000000001,cos(FDe[2])))*60)+' arcminutes in RA and '+FormatFloat(f2,rad2deg*(corr_de)*60)+' arcminutes in DEC by the correction.');
        ComputeCorrection;

--- a/src/pu_sensoranalysis.pas
+++ b/src/pu_sensoranalysis.pas
@@ -269,7 +269,7 @@ Step 7b Calculate dark current method Δσ
       dark_current[e-]:=sqr(σ_end[adu]*gain[e-/adu]) - sqr(σ_read_noise[adu]*gain[e-/adu])    (formula 4)
 
 
-Note a correction for gain in the driver should be applied. E.g. ASI1600 12 bit sensor ouput is increased from 0..4096 to 0..65535. A additional gain factor of 16.
+Note a correction for gain in the driver should be applied. E.g. ASI1600 12 bit sensor output is increased from 0..4096 to 0..65535. A additional gain factor of 16.
 }
 
 
@@ -314,7 +314,7 @@ end;
 procedure Tf_sensoranalysis.FormShow(Sender: TObject);
 begin
   exposure_min := Math.min(0.01, Math.max(camera.ExposureRange.min, 0.0));
-  //protect againt 9999 or -9999 values
+  //protect against 9999 or -9999 values
 
   Gain1.Enabled := camera.CanSetGain;
   Gain2.Enabled := camera.CanSetGain;
@@ -857,7 +857,7 @@ begin
 //  median_and_stdev(1, repeats1.Value, DARK,{out}sd_RTN_dark_adu, sd_dark_adu, median_dark_adu,RTN_perc,RTN_rms);//take an exposure of 1.01 seconds to avoid weird variations in the first second.
 //    RTN_rms:=RTN_rms* 1 / 16;//convert to e-
 //    InstructionsAdd('Percentage of RTN found after '+ IntToStr(dark_current_test_duration1.Value + 1) + ' sec:  ' + floattostrF(RTN_perc, FFfixed, 0, 2)+'%, RMS value '+ floattostrF(RTN_rms, FFfixed, 0, 2)+
-//    ' e-. Random Telegraph Noise is here defined as the number of pixels with a value more then 3 sigma above the Gaussian noise level in the difference betweem two darks.');
+//    ' e-. Random Telegraph Noise is here defined as the number of pixels with a value more then 3 sigma above the Gaussian noise level in the difference between two darks.');
 //  exit;
 
 
@@ -1120,13 +1120,13 @@ begin
           rtn_rms1.caption:= FormatFloat(f2, RTN_rms)+' e-';
           gain_used1.Caption:=IntToStr(gain);
           InstructionsAdd('Percentage of RTN found after 1.01 sec: ' + rtn1.caption+', RMS value '+ rtn_rms1.caption);
-          InstructionsAdd('Random Telegraph Noise is here defined as the number of pixels with a value more then 3 sigma above the Gaussian noise level in the difference betweem two darks.');
+          InstructionsAdd('Random Telegraph Noise is here defined as the number of pixels with a value more then 3 sigma above the Gaussian noise level in the difference between two darks.');
 
           // long duration test
           median_and_stdev(dark_current_test_duration1.Value + 1.01, repeats1.Value, DARK,{out}sd_RTN_dark_adu2, sd_dark_adu2, median_dark_adu2,RTN_perc,RTN_rms);  //take an exposure of value+1 seconds.
           RTN_rms:=RTN_rms* measurements[gainstep].gain_e / correction;//convert to e-
           InstructionsAdd('Percentage of RTN found after '+ IntToStr(dark_current_test_duration1.Value + 1) + ' sec:  ' + FormatFloat(f2,RTN_perc)+'%, RMS value '+ FormatFloat(f2,RTN_rms)+' e-.');
-          InstructionsAdd('Random Telegraph Noise is here defined as the number of pixels with a value more then 3 sigma above the Gaussian noise level in the difference betweem two darks.');
+          InstructionsAdd('Random Telegraph Noise is here defined as the number of pixels with a value more then 3 sigma above the Gaussian noise level in the difference between two darks.');
 
 
           readnoise2_e := sd_dark_adu * measurements[gainstep].gain_e / correction; // read noise after 1.1 seconds        {1.08}

--- a/src/pu_vcurve.lfm
+++ b/src/pu_vcurve.lfm
@@ -252,7 +252,7 @@ object f_vcurve: Tf_vcurve
   object TrackBar1: TTrackBar
     Left = 69
     Height = 43
-    Hint = 'After learning is completed you can use this cursor to better adjust to the linear part of the curve. '#10'The fit must be particulary good near the horizontal blue line position.'
+    Hint = 'After learning is completed you can use this cursor to better adjust to the linear part of the curve. '#10'The fit must be particularly good near the horizontal blue line position.'
     Top = 335
     Width = 89
     OnChange = TrackBar1Change

--- a/src/uDE.pas
+++ b/src/uDE.pas
@@ -157,7 +157,7 @@ begin
     rval := jpl_pleph(@de_eph, @de_iinfo, julian_date, planet_id,
       planet_center, planet_arr, velocity);
 
-    {Results are transfered to vector in array 0..2 and velocity 3..5
+    {Results are transferred to vector in array 0..2 and velocity 3..5
      to find range do - val_range := sqrt(sqr(planet_arr[0]) +  sqr(planet_arr[1]) + sqr(planet_arr[2]))
      Maintain result using barycenter
      }
@@ -395,7 +395,7 @@ end;
 **           radians and radians/day.                                       **
 **                                                                          **
 **           The option is available to have the units in km and km/sec.    **
-**           for this, set km=TRUE at the begining of the program.          **
+**           for this, set km=TRUE at the beginning of the program.         **
 **                                                                          **
 **     calc_velocity = boolean ;  if true,  velocities will be              **
 **           computed,  otherwise not.                                      **
@@ -471,7 +471,7 @@ begin
       if k = 2 then
         lista[9] := list_val;  //for earth,  moon state is needed
       if k = 12 then
-        lista[2] := list_val; //EMBary state additionaly
+        lista[2] := list_val; //EMBary state additionally
     end;
     //make call to state
     jpl_state(eph, ephinfo, et, lista, pv, rrd, 1);

--- a/src/u_annotation.pas
+++ b/src/u_annotation.pas
@@ -360,7 +360,7 @@ begin
       read_deepsky('S',telescope_ra,telescope_dec, cos_telescope_dec {cos(telescope_dec)},fov,{var} ra2,dec2,length1,width1,pa);{deepsky database search}
 
       //5. Conversion (RA,DEC) -> (x,y).
-      sincos(dec2,SIN_dec_new,COS_dec_new);//sincos is faster then seperate sin and cos functions
+      sincos(dec2,SIN_dec_new,COS_dec_new);//sincos is faster then separate sin and cos functions
       delta_ra:=ra2-ra0;
       sincos(delta_ra,SIN_delta_ra,COS_delta_ra);
       HH := SIN_dec_new*sin_dec_ref + COS_dec_new*COS_dec_ref*COS_delta_ra;
@@ -509,7 +509,7 @@ begin
         z:=ImgZoom;
         if z=0 then z:=ImgScale0;
         len:=z*length1/(abs(cdelt2)*60*10*2); {Length in pixels}
-        if len<=2 then {too small to plot an elipse or circle, just plot four dots}
+        if len<=2 then {too small to plot an ellipse or circle, just plot four dots}
         begin {tiny object marking}
           cnv.pixels[x-2,y+2]:=clyellow;
           cnv.pixels[x+2,y+2]:=clyellow;

--- a/src/u_global.pas
+++ b/src/u_global.pas
@@ -233,7 +233,7 @@ type
 
 
   const
-    maxfitslist=15;  // must corespond to value in cdcwcs.c
+    maxfitslist=15;  // must correspond to value in cdcwcs.c
     wcsmain=0; wcsguide=1; wcsfind=2; wcspreview=3; wcsfits=4;
 
   {$i revision.inc}

--- a/src/u_utils.pas
+++ b/src/u_utils.pas
@@ -2442,7 +2442,7 @@ procedure aberrationme(j: double; var abe, abp: double);
 var
   t: double;
 const
-  minjdabe = 2378496.5; // 1800 limit for abberation calculation using Meeus function
+  minjdabe = 2378496.5; // 1800 limit for aberration calculation using Meeus function
   maxjdabe = 2524593.5; // 2200
 begin
   if (j > minjdabe) and (j < maxjdabe) then

--- a/src/ws_bclasses.pas
+++ b/src/ws_bclasses.pas
@@ -44,7 +44,7 @@ Type
 
 var
   {:If @TRUE, than method passed TBThread.Synchronize will be executed directly,
-    without synchronization, useful for libraries and cosole projects.
+    without synchronization, useful for libraries and console projects.
   }
   BauglirSynchronizeThreads: boolean = false;
 

--- a/src/ws_customserver2.pas
+++ b/src/ws_customserver2.pas
@@ -88,7 +88,7 @@ type
     {:Thread suspend method}
     procedure Stop;
 
-    {:Temination procedure
+    {:Termination procedure
       One should call this procedure to terminate thread,
       it internally calls Terminate, but can be overloaded,
       and can be used for clean um
@@ -143,7 +143,7 @@ type
 //  TCustomServerConnections = class of TCustomConnection;
 
   {:Event procedural type to hook OnAfterAddConnection in server
-    Use this hook to get informations about connection accepted server that was added
+    Use this hook to get information about connection accepted server that was added
   }
   TServerAfterAddConnection = procedure (Server: TCustomServer; aConnection: TCustomConnection) of object;
   {:Event procedural type to hook OnBeforeAddConnection in server
@@ -152,15 +152,15 @@ type
   }
   TServerBeforeAddConnection = procedure (Server: TCustomServer; aConnection: TCustomConnection; var CanAdd: boolean) of object;
   {:Event procedural type to hook OnAfterRemoveConnection in server
-    Use this hook to get informations about connection removed from server (connection is closed)
+    Use this hook to get information about connection removed from server (connection is closed)
   }
   TServerAfterRemoveConnection = procedure (Server: TCustomServer; aConnection: TCustomConnection) of object;
   {:Event procedural type to hook OnAfterRemoveConnection in server
-    Use this hook to get informations about connection removed from server (connection is closed)
+    Use this hook to get information about connection removed from server (connection is closed)
   }
   TServerBeforeRemoveConnection = procedure (Server: TCustomServer; aConnection: TCustomConnection) of object;
   {:Event procedural type to hook OnSockedError in server
-    Use this hook to get informations about error on server binding
+    Use this hook to get information about error on server binding
   }
   TServerSocketError = procedure (Server: TCustomServer; Socket: TTCPBlockSocket) of object;
 
@@ -195,7 +195,7 @@ type
 
     function AddConnection(var aSocket: TTCPCustomConnectionSocket): TCustomConnection; virtual;
     {:Main function to determine what kind of connection will be used
-      @link(AddConnection) uses this functino to actually create connection thread
+      @link(AddConnection) uses this function to actually create connection thread
     }
     function CreateServerConnection(aSocket: TTCPCustomConnectionSocket): TCustomConnection; virtual;
     procedure DoAfterAddConnection; virtual;
@@ -221,7 +221,7 @@ type
 
       The same for aPort it may be number or mnemonic port ('23', 'telnet').
 
-      If port value is '0', system chooses itself and conects unused port in the
+      If port value is '0', system chooses itself and connects unused port in the
       range 1024 to 4096 (this depending by operating system!).
 
       Warning: when you call : Bind('0.0.0.0','0'); then is nothing done! In this
@@ -231,7 +231,7 @@ type
     destructor Destroy; override;
     procedure Execute; override;
 
-    {:Temination procedure
+    {:Termination procedure
       This method should be called instead of Terminate to terminate thread,
       it internally calls Terminate, but can be overloaded,
       and can be used for data clean up

--- a/src/ws_websocket2.pas
+++ b/src/ws_websocket2.pas
@@ -70,7 +70,7 @@ uses
   ws_customserver2, strutils;
 
 const
-  {:Constants section defining what kind of data are sent from one pont to another}
+  {:Constants section defining what kind of data are sent from one point to another}
   {:Continuation frame }
   wsCodeContinuation = $0;
   {:Text frame }
@@ -223,25 +223,25 @@ type
 
     {:Overload this function to process connection close (not at socket level, but as an actual WebSocket frame)
       aCloseCode represents close code (see wsClose constants)
-      aCloseReason represents textual information transfered with frame (there is no specified format or meaning)
+      aCloseReason represents textual information transferred with frame (there is no specified format or meaning)
       aClosedByPeer whether connection has been closed by this connection object or by peer endpoint
     }
     procedure ProcessClose(aCloseCode: integer; aCloseReason: string; aClosedByPeer: boolean); virtual;
 
 
     {:Overload this function to process data as soon as they are read before other Process<data> function is called
-      this function should be used by extensions to modify incomming data before the are process based on code
+      this function should be used by extensions to modify incoming data before the are process based on code
     }
     procedure ProcessData(var aFinal: boolean; var aRes1: boolean; var aRes2: boolean; var aRes3: boolean; var aCode: integer; aData: TMemoryStream); virtual;
 
 
     {:Overload this function to process ping frame)
-      aData represents textual information transfered with frame (there is no specified format or meaning)
+      aData represents textual information transferred with frame (there is no specified format or meaning)
     }
     procedure ProcessPing(aData: string); virtual;
 
     {:Overload this function to process pong frame)
-      aData represents textual information transfered with frame (there is no specified format or meaning)
+      aData represents textual information transferred with frame (there is no specified format or meaning)
     }
     procedure ProcessPong(aData: string); virtual;
 
@@ -284,7 +284,7 @@ type
 
     {:Procedure to close connection
       aCloseCode represents close code (see wsClose constants)
-      aCloseReason represents textual information transfered with frame (there is no specified format or meaning) the string can only be 123 bytes length
+      aCloseReason represents textual information transferred with frame (there is no specified format or meaning) the string can only be 123 bytes length
     }
     procedure Close(aCode: integer; aCloseReason: string); virtual; abstract;
 
@@ -337,16 +337,16 @@ type
     procedure SendTextContinuation(aData: string; aFinal: boolean = true; aRes1: boolean = false;  aRes2: boolean = false;  aRes3: boolean = false);
 
     {:Send Ping
-      aData ping informations
+      aData ping information
     }
     procedure Ping(aData: string);
 
     {:Send Pong
-      aData pong informations
+      aData pong information
     }
     procedure Pong(aData: string);
 
-    {:Temination procedure
+    {:Termination procedure
       This method should be called instead of Terminate to terminate thread,
       it internally calls Terminate, but can be overloaded,
       and can be used for data clean up
@@ -376,7 +376,7 @@ type
       e.g. foo, bar; baz=2
 
       On both client and server connection this value represents the extension(s) selected by server to be used
-      as a result of extension negotioation
+      as a result of extension negotiation
 
       value - represents that no extension was negotiated and no header will be sent to client
       it is the default value
@@ -391,7 +391,7 @@ type
 
 
     {:
-      Whether WebSocket handshake was succecfull (and connection is afer WS handshake) 
+      Whether WebSocket handshake was succecfull (and connection is after WS handshake) 
     }
     property Handshake: boolean read fHandshake;
 
@@ -412,7 +412,7 @@ type
       e.g. chat, superchat
 
       On both client and server connection this value represents the protocol(s) selected by server to be used
-      as a result of protocol negotioation
+      as a result of protocol negotiation
 
       value - represents that no protocol was negotiated and no header will be sent to client
       it is the default value
@@ -475,14 +475,14 @@ type
   {: Class of WebSocket server connections }
   TWebSocketServerConnections = class of TWebSocketServerConnection;
 
-  {: WebSocket client connection, this object shoud be created to establish client to server connection  }
+  {: WebSocket client connection, this object should be created to establish client to server connection  }
   TWebSocketClientConnection = class(TWebSocketCustomConnection)
   protected
     function BeforeExecuteConnection: boolean; override;
   public
     {: construstor to create connection,
-      parameters has the same meaning as corresponging connection properties (see 2 differences below) and
-      should be formated according to headers values
+      parameters has the same meaning as corresponding connection properties (see 2 differences below) and
+      should be formatted according to headers values
 
       aProtocol and aExtension in constructor represents protocol(s) and extension(s)
       client is trying to negotiate, obejst properties then represents
@@ -583,7 +583,7 @@ type
     procedure CloseAllConnections(aCloseCode: integer; aReason: string);
 
 
-    {:Temination procedure
+    {:Termination procedure
       This method should be called instead of Terminate to terminate thread,
       it internally calls Terminate, but can be overloaded,
       and can be used for data clean up
@@ -1128,7 +1128,7 @@ begin
       result := ReadData(fReadFinal,  fReadRes1, fReadRes2, fReadRes3, fReadCode, fReadStream);
       if (CanReceiveOrSend)  then
       begin
-        if (result = 0) then // no socket error occured
+        if (result = 0) then // no socket error occurred
         begin
           fReadStream.Position := 0;
           ProcessData(fReadFinal,  fReadRes1, fReadRes2, fReadRes3, fReadCode, fReadStream);
@@ -1371,7 +1371,7 @@ begin
           begin
             try
               try
-                // BASIC INFORMATIONS
+                // BASIC INFORMATION
                 aFinal := (b and $80) = $80;
                 aRes1 := (b and $40) = $40;
                 aRes2 := (b and $20) = $20;
@@ -1571,7 +1571,7 @@ begin
 
       s := '';
 
-      // BASIC INFORMATIONS
+      // BASIC INFORMATION
       b := IfThen(aFinal, 1, 0) * $80;
       b := b + IfThen(aRes1, 1, 0) * $40;
       b := b + IfThen(aRes2, 1, 0) * $20;


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.rtf,*.440,./component/xmlparser/Licence.txt" -L aafter,abd,acount,afe,aixs,aline,anormal,aother,aparent,apoints,aprogram,asender,bbefore,childs,comform,connecton,currenty,cursos,daed,defaulty,dout,ede,enty,fo,groupt,imform,ist,iterm,maccro,macth,nax,nd,ned,nnumber,precess,pinter,precessed,readin,requir,ser,servent,struc,te,tolen,udo`